### PR TITLE
EOBS-1889_partial_reason_popup

### DIFF
--- a/features/3in1_risk_score_calculation.feature
+++ b/features/3in1_risk_score_calculation.feature
@@ -21,8 +21,8 @@ Feature: NEWS Score/Risk for 3in1 cases.
     And the value <AVPU> is selected in the AVPU field
     And the value <sup_o2> is selected in the Patient on supplemental O2 field
     Then the form is submitted
-    And the Score submitted is <score>
-    And the Clinical Risk submitted is <risk>
+    And the Full Score submitted is <score>
+    And the Full Clinical Risk submitted is <risk>
     And the NEWS observation is confirmed
 
   Examples:

--- a/features/submit_full_neurological_obs.feature
+++ b/features/submit_full_neurological_obs.feature
@@ -24,7 +24,7 @@ Scenario Outline: Neurological observation is correctly submitted
     And the value <limb_left_leg> is selected in the Limb Movement - Left Leg field
     And the value <limb_right_leg> is selected in the Limb Movement - Right Leg field
     Then the form is submitted
-    And the Score submitted is <score>
+    And the Full Score submitted is <score>
     And the Neurological observation is confirmed
 
   Examples:

--- a/features/submit_news_obs_risk_score_calculation.feature
+++ b/features/submit_news_obs_risk_score_calculation.feature
@@ -21,8 +21,8 @@ Feature: NEWS observation. Calculate Score/Risk.
     And the value <AVPU> is selected in the AVPU field
     And the value <sup_o2> is selected in the Patient on supplemental O2 field
     Then the form is submitted
-    And the Score submitted is <score>
-    And the Clinical Risk submitted is <risk>
+    And the Full Score submitted is <score>
+    And the Full Clinical Risk submitted is <risk>
     And the NEWS observation is confirmed
 
   Examples:

--- a/features/submit_news_obs_risk_score_calculation.feature
+++ b/features/submit_news_obs_risk_score_calculation.feature
@@ -47,7 +47,6 @@ Feature: NEWS observation. Calculate Score/Risk.
     | 23        | 91     | 35.0        | 220    | 80     | 40    | Voice         | No     | High    | 17    |
     | 25        | 91     | 35.0        | 220    | 80     | 40    | Voice         | No     | High    | 18    |
 
-
   Scenario Outline: NEWS Observation is correctly submitted. Risk and Score 19 & 20
     Given a user with the Nurse role logs into the app
     And they view the My Patients list

--- a/features/submit_news_obs_risk_score_calculation.feature
+++ b/features/submit_news_obs_risk_score_calculation.feature
@@ -47,32 +47,31 @@ Feature: NEWS observation. Calculate Score/Risk.
     | 23        | 91     | 35.0        | 220    | 80     | 40    | Voice         | No     | High    | 17    |
     | 25        | 91     | 35.0        | 220    | 80     | 40    | Voice         | No     | High    | 18    |
 
-#  Following scenarios currently blocked by EOBS-1864
-#
-#  Scenario Outline: NEWS Observation is correctly submitted. Risk and Score 19 & 20
-#    Given a user with the Nurse role logs into the app
-#    And they view the My Patients list
-#    And the My Patients list has loaded
-#    When Patient Doyle, Worth Scott is selected
-#    And the Take observation button is selected
-#    And the NEWS observation is selected from the list
-#    Then the NEWS observation form is displayed
-#    When the value <resp_rate> is inputted in the Respiration Rate field
-#    And the value <o2_sat> is inputted in the O2 Saturation field
-#    And the value <temperature> is inputted in the Body Temperature field
-#    And the value <bp_sys> is inputted in the Blood Pressure Systolic field
-#    And the value <bp_dias> is inputted in the Blood Pressure Diastolic field
-#    And the value <pulse> is inputted in the Pulse Rate field
-#    And the value <AVPU> is selected in the AVPU field
-#    And the value <sup_o2> is selected in the Patient on supplemental O2 field
-#    And the value <device_type> is selected in the O2 Device field
-#    And the value <flow_rate> is inputted in the Flow Rate (l/min) field
-#    Then the form is submitted
-#    And the Score submitted is <score>
-#    And the Clinical Risk submitted is <risk>
-#    And the NEWS observation is confirmed
-#
-#  Examples:
-#    | resp_rate | o2_sat | temperature | bp_sys | bp_dias| pulse | AVPU          | sup_o2 | device_type   | flow_rate | risk   | score |
-#    | 25        | 90     | 40.0        | 220    | 80     | 40    | Pain          | Yes    | Nasal Cannula | 82        |High    | 19    |
-#    | 8         | 90     | 35.0        | 221    | 80     | 39    | Unresponsive  | Yes    | Nasal Cannula | 82        |High    | 20    |
+
+  Scenario Outline: NEWS Observation is correctly submitted. Risk and Score 19 & 20
+    Given a user with the Nurse role logs into the app
+    And they view the My Patients list
+    And the My Patients list has loaded
+    When Patient Doyle, Worth Scott is selected
+    And the Take observation button is selected
+    And the NEWS observation is selected from the list
+    Then the NEWS observation form is displayed
+    When the value <resp_rate> is inputted in the Respiration Rate field
+    And the value <o2_sat> is inputted in the O2 Saturation field
+    And the value <temperature> is inputted in the Body Temperature field
+    And the value <bp_sys> is inputted in the Blood Pressure Systolic field
+    And the value <bp_dias> is inputted in the Blood Pressure Diastolic field
+    And the value <pulse> is inputted in the Pulse Rate field
+    And the value <AVPU> is selected in the AVPU field
+    And the value <sup_o2> is selected in the Patient on supplemental O2 field
+    And the value <device_type> is selected in the O2 Device field
+    And the value <flow_rate> is inputted in the Flow Rate (l/min) field
+    Then the form is submitted
+    And the Full Score submitted is <score>
+    And the Full Clinical Risk submitted is <risk>
+    And the NEWS observation is confirmed
+
+  Examples:
+    | resp_rate | o2_sat | temperature | bp_sys | bp_dias| pulse | AVPU          | sup_o2 | device_type   | flow_rate | risk   | score |
+    | 25        | 90     | 40.0        | 220    | 80     | 40    | Pain          | Yes    | Nasal Cannula | 82        |High    | 19    |
+    | 8         | 90     | 35.0        | 221    | 80     | 39    | Unresponsive  | Yes    | Nasal Cannula | 82        |High    | 20    |

--- a/features/submit_partial_news_obs.feature
+++ b/features/submit_partial_news_obs.feature
@@ -1,0 +1,36 @@
+# Created by Nayira.Sanchez at 21/09/2017
+# JIRA: Not Available - Need to define
+# Scenarios covered:
+
+Feature: Partial NEWS obs - Submit with Reason 'Asleep'
+
+  Scenario Outline: Submission of Partial NEWS Observation
+    Given a user with the Nurse role logs into the app
+    And they view the My Patients list
+    And the My Patients list has loaded
+    When Patient Doyle, Worth Scott is selected
+    And the Take observation button is selected
+    And the NEWS observation is selected from the list
+    Then the NEWS observation form is displayed
+    When the value <resp_rate> is inputted in the Respiration Rate field
+    And the value <o2_sat> is inputted in the O2 Saturation field
+    And the value <temperature> is inputted in the Body Temperature field
+    And the value <bp_sys> is inputted in the Blood Pressure Systolic field
+    And the value <bp_dias> is inputted in the Blood Pressure Diastolic field
+    And the value <pulse> is inputted in the Pulse Rate field
+    And the value <AVPU> is selected in the AVPU field
+    And the value <sup_o2> is selected in the Patient on supplemental O2 field
+    Then the form is submitted
+    And the Reason for partial observation popup is displayed
+    And the reason <reason> is selected
+    And the Partial Score submitted is <score>
+    And the Partial Clinical Risk submitted is <risk>
+    And the Partial NEWS observation is confirmed
+
+  Examples:
+    | resp_rate | o2_sat | temperature | bp_sys | bp_dias| pulse | AVPU          | sup_o2         | risk    | score | reason            |
+    | 12        | 96     | 36.1        | 111    | 80     | 51    | Alert         | Please Select  | No      | 0     | Asleep            |
+    | 12        | 96     | 35.0        | 111    | 80     | 51    | Alert         | Please Select  | Medium  | 3     | Request By Doctor |
+    | 10        | 96     | 36.0        | 92     | 80     | 95    | Alert         | Please Select  | Medium  | 5     | Patient Aggression|
+    | 12        | 92     | 36.1        | 111    | 80     | 51    | Alert         | Please Select  | Low     | 2     | Patient Aggression|
+    | 10        | 96     | 35.0        | 111    | 80     | 40    | Alert         | Please Select  | High    | 7     | Refused           |

--- a/features/user_permissions.feature
+++ b/features/user_permissions.feature
@@ -25,7 +25,7 @@ Feature: User Permissions for Tasks
       | Assess Patient                        |
       | Inform Shift Coordinator              |
       | Review Frequency                      |
-      | Urgently Inform Medical Team          |
+      | Urgently inform medical team          |
       | Immediately Inform Medical Team       |
       | Inform Medical Team?                  |
       | Call an Ambulance (2222/9999)         |
@@ -33,6 +33,7 @@ Feature: User Permissions for Tasks
       | F&F - 6am Fluid Intake Review         |
       | F&F - 3pm Fluid Intake Review         |
       | NEWS Observation                      |
+      | Inform FY2                            |
 
   Scenario: Mobile Task List Permissions for Doctor
     Given a user with the Doctor role logs into the app

--- a/steps/mobile_common_actions.py
+++ b/steps/mobile_common_actions.py
@@ -220,15 +220,21 @@ def submit_the_form(context):
 def confirm_calculated_value(
         context, obs_type, value_to_check, expected_value):
     """
-    Gets and verifies a value (clinical risk or score) displayed in the partial
+    Gets and verifies a value (clinical risk or score) displayed in the
     submission confirmation popup
+
+    Expected Data examples:
+
+    .. code-block:: gherkin
+
+        Then the Full Score submitted is 12
+
     :param context: behave driver
     :param obs_type: specifies using regex or locators to match against the
-    value_to_check parameter
+        value_to_check parameter
     :param value_to_check: The value 'name' to look for. Refers to a specific
-    locator in the page, by text
-    :param expected_value: the value expected. Example: 'No' Clinical Risk or
-    '2' Score
+        locator in the page, by text
+    :param expected_value: the value expected.
     :return: boolean
     """
     popup_options = ModalPage(context.driver)

--- a/steps/strings.py
+++ b/steps/strings.py
@@ -1,0 +1,25 @@
+""" Regex foo """
+
+# pylint: disable=anomalous-backslash-in-string
+
+import re
+
+
+PARTIAL_NEWS_CLINICAL_RISK = \
+    "At least (\w+) clinical risk, real risk may be higher"
+PARTIAL_NEWS_SCORE = "At least (\d+) NEWS score, real NEWS score may be higher"
+OBS_TITLE = "Successfully Submitted (\w+.)?(\w+) Observation"
+REGEXES = {
+    'Clinical Risk': PARTIAL_NEWS_CLINICAL_RISK,
+    'Score': PARTIAL_NEWS_SCORE,
+    'OBS': OBS_TITLE
+}
+
+
+def get_string_regex(nice_human_name):
+    """
+    Get a string regex by supplying a nicer name or something, I dunno
+    :param nice_human_name:
+    :return:
+    """
+    return re.compile(REGEXES.get(nice_human_name))

--- a/steps/strings.py
+++ b/steps/strings.py
@@ -16,10 +16,11 @@ REGEXES = {
 }
 
 
-def get_string_regex(nice_human_name):
+def get_string_regex(element_reference):
     """
-    Get a string regex by supplying a nicer name or something, I dunno
-    :param nice_human_name:
-    :return:
+    Get a string regex by supplying an element reference as a parameter
+
+    :param element_reference: reference to the specific regex
+    :return: regex object
     """
-    return re.compile(REGEXES.get(nice_human_name))
+    return re.compile(REGEXES.get(element_reference))


### PR DESCRIPTION
EOBS-1889_partial_reason_popup

# Features Added/Changed:
- Refactored step confirm_calculated_value to include regex match for… partial observations submission
- Edited gherkin on 3in1_risk_score_calculation and submit_news_obs_risk_score_calculation to match refactored step
- Added submit_partial_news_obs feature
- Added string.py file to contain regex list - this contains a 'disable' line for 'anomalous-backslash-in-string' due to regex syntax

# Feature file checks:
- [x] JIRA ticket reference number
- [x] Scenarios covered listed
Notes: At the time of PR, this 'Story' does not exist in JIRA - need to edit in the future

# Possible issues:
Adding regex checks for Score and Clinical Risk on the popup. Might need to refactor to include other obs types and/or include regex for full obs for better coverage.


# General Checks:
- [x] Linting passing with score 10/10 (Happy Travis!)
- [x] All Tests passing on local run
- [x] All commented out code has a reason for it documented
- [x] All methods have a detailed docstring / changed methods have updated docstring
- [x] Documentation up to date
- [x] Timings on expected conditions reviewed
- [x] Deprecated selectors reviewed
- [x] Code re-usability reviewed