### PR TITLE
Pinning Headless Chrome Selenium Docker Image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,10 @@ install:
 	venv/bin/pip install -r requirements.txt
 
 setup_chrome:
-	@docker pull yukinying/chrome-headless-browser-selenium
+	@docker pull yukinying/chrome-headless-browser-selenium:64.0.3278.0
 
 run_chrome:
-	@docker run -d --name selenium --shm-size=1024m --cap-add SYS_ADMIN -p 0.0.0.0:4444:4444 yukinying/chrome-headless-browser-selenium
+	@docker run -d --name selenium --shm-size=1024m --cap-add SYS_ADMIN -p 0.0.0.0:4444:4444 yukinying/chrome-headless-browser-selenium:64.0.3278.0
 
 stop_chrome:
 	@docker stop selenium || /bin/true


### PR DESCRIPTION
- Pinning `yukinying/chrome-headless-browser-selenium` to `64.0.3278.0` as 65+ breaks the automation tests

# Features Added/Changed:
N/A

# Feature file checks:
N/A

# Possible issues:
Should fix issue where automation isn't working in GoCD


# General Checks:
- [ ] Linting passing with score 10/10 (Happy Travis!)
- [ ] All Tests passing on local run
- [ ] All commented out code has a reason for it documented
- [ ] All methods have a detailed docstring / changed methods have updated docstring
- [ ] Documentation up to date
- [ ] Timings on expected conditions reviewed
- [ ] Deprecated selectors reviewed
- [ ] Code re-usability reviewed